### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,8 +6,8 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-STATE_t KEYWORD1
-BLINK_STATE_t KEYWORD1
+STATE_t	KEYWORD1
+BLINK_STATE_t	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
@@ -33,9 +33,9 @@ LEDeasy	KEYWORD2
 #######################################
 
 OFF	LITERAL1
-ON  LITERAL1
-SLOW  LITERAL1
-MED LITERAL1
-FAST  LITERAL1
-BLINK_OFF LITERAL1
-BLINK_ON  LITERAL1
+ON	LITERAL1
+SLOW	LITERAL1
+MED	LITERAL1
+FAST	LITERAL1
+BLINK_OFF	LITERAL1
+BLINK_ON	LITERAL1


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords